### PR TITLE
Fix: allow HTTP and local URL connections

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -8,5 +8,10 @@
     <string/>
     <key>CFBundleIconName</key>
     <string>AppIcon</string>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+      <key>NSAllowsLocalNetworking</key>
+      <true/>
+    </dict>
   </dict>
 </plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,7 +27,7 @@
       "iconAsTemplate": true
     },
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; connect-src 'self' wss://* https://*; style-src 'self' 'unsafe-inline'; img-src 'self' data:;"
+      "csp": "default-src 'self'; script-src 'self'; connect-src 'self' wss://* ws://* https://* http://*; style-src 'self' 'unsafe-inline'; img-src 'self' data:;"
     }
   },
   "bundle": {

--- a/src/shared/errorNormalization.ts
+++ b/src/shared/errorNormalization.ts
@@ -79,7 +79,7 @@ export function normalizeConnectionError(
     str.includes("ats") ||
     str.includes("insecure load")
   ) {
-    return "Cleartext HTTP blocked by macOS App Transport Security. Use https:// or a .local address.";
+    return "Cleartext HTTP blocked by macOS App Transport Security. Use https:// or a local network address (e.g., .local, localhost, or LAN IP).";
   }
 
   return typeof errCode === "string" ? errCode : `Connection error: ${errCode}`;

--- a/src/shared/errorNormalization.ts
+++ b/src/shared/errorNormalization.ts
@@ -76,7 +76,6 @@ export function normalizeConnectionError(
   if (
     str.includes("cleartext") ||
     str.includes("app transport security") ||
-    str.includes("ats") ||
     str.includes("insecure load")
   ) {
     return "Cleartext HTTP blocked by macOS App Transport Security. Use https:// or a local network address (e.g., .local, localhost, or LAN IP).";

--- a/src/shared/errorNormalization.ts
+++ b/src/shared/errorNormalization.ts
@@ -73,6 +73,14 @@ export function normalizeConnectionError(
   if (str.includes("timeout") || str.includes("timed out")) {
     return "Connection timed out. The server may be unreachable.";
   }
+  if (
+    str.includes("cleartext") ||
+    str.includes("app transport security") ||
+    str.includes("ats") ||
+    str.includes("insecure load")
+  ) {
+    return "Cleartext HTTP blocked by macOS App Transport Security. Use https:// or a .local address.";
+  }
 
   return typeof errCode === "string" ? errCode : `Connection error: ${errCode}`;
 }


### PR DESCRIPTION
## Summary

Most Home Assistant installs use HTTP with mDNS (e.g. `http://homeassistant.local:8123`) or plain IP addresses. These connections were failing because:

- The CSP only allowed `wss://` and `https://` in `connect-src`
- macOS App Transport Security blocks cleartext HTTP to non-localhost domains by default

This adds `ws://` and `http://` to the CSP and enables `NSAllowsLocalNetworking` in the macOS ATS config. `NSAllowsLocalNetworking` restricts cleartext HTTP at the OS level to local targets (`.local` domains, IPs, and unqualified hostnames). The CSP itself is broader (`http://*`, `ws://*`) to accommodate LAN IP connections that can't be expressed with CSP wildcards — the ATS policy is the primary security boundary on macOS.

Also adds error pattern matching for ATS failures so users see actionable messages instead of opaque errors.