### PR TITLE
Fix: handle connection timeouts and allow retry

### DIFF
--- a/src/components/settings/ConnectionStatus.tsx
+++ b/src/components/settings/ConnectionStatus.tsx
@@ -3,9 +3,11 @@
  * @module settings/components/ConnectionStatus
  */
 
+import { useState } from "react";
 import { Status } from "@/components/ui/Status";
 import { useHaConnectionStatus } from "@/hooks/useHaStates";
 import { useSettings } from "@/hooks/useSettings";
+import { hasCredentials, retryConnection } from "@/services/haConnection";
 import { formatConnectionStatus } from "@/shared";
 
 /** Maps connection status to color palette */
@@ -23,9 +25,20 @@ const STATUS_COLORS: Record<string, "green" | "yellow" | "red" | "gray"> = {
 export function ConnectionStatus() {
   const { settings } = useSettings();
   const { status, error } = useHaConnectionStatus();
+  const [retrying, setRetrying] = useState(false);
 
   const colorPalette = STATUS_COLORS[status] || "gray";
   const isConnecting = status === "connecting";
+  const showRetry = status === "disconnected" && hasCredentials() && !retrying;
+
+  const handleRetry = async () => {
+    setRetrying(true);
+    try {
+      await retryConnection();
+    } finally {
+      setRetrying(false);
+    }
+  };
 
   return (
     <div className="flex items-center gap-2 py-2.5 px-3 rounded-md text-sm bg-bg-muted">
@@ -36,6 +49,15 @@ export function ConnectionStatus() {
           useEllipsisChar: true,
         })}
       </span>
+      {showRetry && (
+        <button
+          type="button"
+          onClick={handleRetry}
+          className="ml-auto text-fg-muted hover:text-fg cursor-pointer text-sm"
+        >
+          Retry
+        </button>
+      )}
     </div>
   );
 }

--- a/src/services/haConnection.ts
+++ b/src/services/haConnection.ts
@@ -286,8 +286,13 @@ export async function connect(url: string, token: string): Promise<void> {
     // Create auth with long-lived token
     const auth = createLongLivedTokenAuth(normalizedUrl, token);
 
-    // Create connection
-    state.connection = await createConnection({ auth });
+    // Create connection with timeout to avoid hanging when server is unreachable
+    state.connection = await Promise.race([
+      createConnection({ auth }),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("Connection timed out")), TIMING.CONNECTION_TIMEOUT_MS)
+      ),
+    ]);
     log("Connected, HA version:", state.connection.haVersion);
 
     setupConnectionListeners(state.connection);

--- a/src/services/haConnection.ts
+++ b/src/services/haConnection.ts
@@ -282,6 +282,9 @@ export async function connect(url: string, token: string): Promise<void> {
   const normalizedUrl = normalizeUrl(url.trim(), { defaultProtocol: "https" });
   log("Connecting to", normalizedUrl);
 
+  // Store credentials early so reconnect is available if connection fails
+  state.credentials = { url: normalizedUrl, token };
+
   try {
     // Create auth with long-lived token
     const auth = createLongLivedTokenAuth(normalizedUrl, token);
@@ -298,8 +301,7 @@ export async function connect(url: string, token: string): Promise<void> {
     setupConnectionListeners(state.connection);
     setupEntitySubscription(state.connection);
 
-    // Store credentials for wake reconnection and start wake detection
-    state.credentials = { url: normalizedUrl, token };
+    // Start wake detection for automatic reconnection after sleep
     startWakeDetection();
 
     setStatus("connected");
@@ -309,6 +311,7 @@ export async function connect(url: string, token: string): Promise<void> {
     logError("Connection failed:", errMsg);
 
     if (errCode === ERR_INVALID_AUTH) {
+      state.credentials = null;
       setStatus("auth_invalid", errMsg);
     } else {
       setStatus("disconnected", errMsg);

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -13,6 +13,8 @@ export const TIMING = {
   WAKE_CHECK_INTERVAL_MS: 15000,
   /** Grace period added to wake check interval to detect sleep gaps */
   WAKE_THRESHOLD_GRACE_MS: 5000,
+  /** Timeout for initial WebSocket connection attempts */
+  CONNECTION_TIMEOUT_MS: 10000,
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

When the Home Assistant server is unreachable, the WebSocket connection attempt would hang indefinitely with no feedback. This adds:

- A 10s timeout on the initial WebSocket connection so it fails fast instead of hanging
- Credentials are stored before the connection attempt so reconnect is possible on failure (previously they were only stored on success)
- A retry button in the settings connection status banner when disconnected
- Credentials are cleared on auth errors so a stale retry button isn't shown